### PR TITLE
Updated TtfbTimeout to 25 seconds

### DIFF
--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -34,7 +34,7 @@ var mainnetNetworkConfig = &NetworkConfig{
 	AttestationSubnetCount:          64,
 	AttestationPropagationSlotRange: 32,
 	MaxRequestBlocks:                1 << 10, // 1024
-	TtfbTimeout:                     5 * time.Second,
+	TtfbTimeout:                     25 * time.Second,
 	RespTimeout:                     10 * time.Second,
 	MaximumGossipClockDisparity:     500 * time.Millisecond,
 	MessageDomainInvalidSnappy:      [4]byte{00, 00, 00, 00},


### PR DESCRIPTION
Increased TtfbTimeout to 25 seconds, as the status request sometimes take more than 13 to 15 seconds to process, due to the lock taken by ReceiveBlockBatch, which takes around 13 seconds to 15 seconds to process a batch of 64 blocks.

The failure to respond the status request within the timeout results into the banning of the peer who failed and thus halts the syncing for next 2 hours, where the score for the banned peer is re-evaluated.